### PR TITLE
Allow anchor characters

### DIFF
--- a/lib/regxing/regex.rb
+++ b/lib/regxing/regex.rb
@@ -98,18 +98,28 @@ module RegXing
       expression.inspect[1..-2]
     end
 
+    def is_anchor(char)
+      RegXing::Regex.anchors.any? {|exp| char.match(exp) }
+    end
+
+    def is_indicator(first, second=nil)
+      RegXing::Regex.count_indicators.any? {|exp| second && second.match(exp) }
+    end
+
     def split
       arr = to_s.scan(/\\\?|[^\\]?\?|\\\.|[^\\]?\.|\\\+|[^\\]?\+|\\\*|[^\\]?\*|\\[a-zA-Z]|(?<!\\)[a-zA-Z]|\{\d*\,?\d*\}|\[\[\:.{5,6}\:\]\]|./).flatten
 
       arr.each_with_index do |item, index|
-        if RegXing::Regex.count_indicators.any? {|exp| arr[index + 1] && arr[index + 1].match(exp) }
+        if is_indicator(item, arr[index + 1])
           arr[index] = [ item, RegXing::Regex.process_count_indicator(arr.delete_at(index + 1)) ]
+        elsif is_anchor(item)
+          arr[index] = nil
         else
           arr[index] = [item, 1]
         end
       end
 
-      arr
+      arr.compact
     end
   end
 end

--- a/lib/regxing/regex.rb
+++ b/lib/regxing/regex.rb
@@ -34,6 +34,10 @@ module RegXing
         [ /(?<!\\)\*/, /(?<!\\)\+/, /(?<!\\)\?/, /\{\d*\,?\d*\}/ ]
       end
 
+      def anchors
+        [ /^\^/, /\$$/ ]
+      end
+
       def process_count_indicator(indicator)
         if indicator.match count_indicators.last
 

--- a/spec/lib/regxing/generator/less_simple_expression_spec.rb
+++ b/spec/lib/regxing/generator/less_simple_expression_spec.rb
@@ -4,5 +4,10 @@ describe RegXing::Generator do
       let(:expression) { /\w{3}/ }
       it_behaves_like "a matching string generator"
     end
+
+    describe "anchors" do
+      let(:expression) { /^\d{3}$/ }
+      it_behaves_like "a matching string generator"
+    end
   end
 end


### PR DESCRIPTION
This PR causes RegXing to ignore characters `^` and `$` when they are used as anchors (i.e. denote the beginning/end of a string). This is because RegXing always assumes that the expression encompasses the entirety of the desired string.
