### PR TITLE
Test for accepting the or operator

### DIFF
--- a/spec/lib/regxing/generator/less_simple_expression_spec.rb
+++ b/spec/lib/regxing/generator/less_simple_expression_spec.rb
@@ -9,5 +9,10 @@ describe RegXing::Generator do
       let(:expression) { /^\d{3}$/ }
       it_behaves_like "a matching string generator"
     end
+
+    describe "or operators" do
+      let(:expression) { /a|b/ }
+      it_behaves_like "a matching string generator"
+    end
   end
 end


### PR DESCRIPTION
This PR adds a test to make sure the `|` operator is handled within the regex. Turns out this is already supported.
