### PR TITLE
Remove posix expression support

### DIFF
--- a/lib/regxing/regex.rb
+++ b/lib/regxing/regex.rb
@@ -15,18 +15,7 @@ module RegXing
           /\\h/                => random_hexdigit_character,
           /\\H/                => random_non_hexdigit_character,
           /\\s/                => " ",
-          /\\S/                => random_letter,
-          /\[\[\:alnum\:\]\]/  => random_letter,
-          /\[\[\:alpha\:\]\]/  => random_letter,
-          /\[\[\:digit\:\]\]/  => random_number,
-          /\[\[\:graph\:\]\]/  => random_letter,
-          /\[\[\:lower\:\]\]/  => random_lowercase_letter,
-          /\[\[\:print\:\]\]/  => random_letter,
-          /\[\[\:xdigit\:\]\]/ => random_hexdigit_character,
-          /\[\[\:punct\:\]\]/  => random_non_word_character,
-          /\[\[\:space\:\]\]/  => " ",
-          /\[\[\:cntrl\:\]\]/  => "\a",
-          /\[\[\:upper\:\]\]/  => random_uppercase_letter
+          /\\S/                => random_letter
         }
       end
 

--- a/spec/lib/regxing/generator/simple_expression_spec.rb
+++ b/spec/lib/regxing/generator/simple_expression_spec.rb
@@ -53,63 +53,6 @@ describe RegXing::Generator do
         end
       end
 
-      context "POSIX bracket expressions" do
-        context "alphanumeric" do
-          let(:expression) { /[[:alnum:]]/ }
-          it_behaves_like "a matching string generator"
-        end
-
-        context "letters" do
-          let(:expression) { /[[:alpha:]]/ }
-          it_behaves_like "a matching string generator"
-        end
-
-        context "numbers" do
-          let(:expression) { /[[:digit:]]/ }
-          it_behaves_like "a matching string generator"
-        end
-
-        context "non-blank characters" do
-          let(:expression) { /[[:graph:]]/ }
-          it_behaves_like "a matching string generator"
-        end
-
-        context "lowercase letters" do
-          let(:expression) { /[[:lower:]]/ }
-          it_behaves_like "a matching string generator"
-        end
-
-        context "uppercase letters" do
-          let(:expression) { /[[:upper:]]/ }
-          it_behaves_like "a matching string generator"
-        end
-
-        context "print character" do
-          let(:expression) { /[[:print:]]/ }
-          it_behaves_like "a matching string generator"
-        end
-
-        context "hexdigit characters" do
-          let(:expression) { /[[:xdigit:]]/ }
-          it_behaves_like "a matching string generator"
-        end
-
-        context "punctuation" do
-          let(:expression) { /[[:punct:]]/ }
-          it_behaves_like "a matching string generator"
-        end
-
-        context "whitespace" do
-          let(:expression) { /[[:space:]]/ }
-          it_behaves_like "a matching string generator"
-        end
-
-        context "control characters" do
-          let(:expression) { /[[:cntrl:]]/ }
-          it_behaves_like "a matching string generator"
-        end
-      end
-
       context "literals" do
         context "alphanumeric" do
           let(:expression) { /a/ }


### PR DESCRIPTION
This PR removes support for POSIX bracket expressions. Support may be added back in future versions, but at this point it was necessary to prioritize other features and it was determined it would be easier to add POSIX bracket expressions back later than it would be to work around them now. 
